### PR TITLE
FIx broken dprint 0.41 in darwin

### DIFF
--- a/pkgs/development/tools/dprint/default.nix
+++ b/pkgs/development/tools/dprint/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchCrate, rustPlatform, libiconv, Security }:
+{ lib, stdenv, fetchCrate, rustPlatform, libiconv, Security, darwin }:
 
 rustPlatform.buildRustPackage rec {
   pname = "dprint";
@@ -13,8 +13,8 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optionals stdenv.isDarwin [
     Security
-    pkgs.darwin.apple_sdk_11_0.frameworks.CoreFoundation
-    pkgs.darwin.apple_sdk_11_0.frameworks.SystemConfiguration
+    darwin.apple_sdk_11_0.frameworks.CoreFoundation
+    darwin.apple_sdk_11_0.frameworks.SystemConfiguration
     libiconv
   ];
 

--- a/pkgs/development/tools/dprint/default.nix
+++ b/pkgs/development/tools/dprint/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchCrate, rustPlatform, libiconv, Security, Foundation }:
+{ lib, stdenv, fetchCrate, rustPlatform, libiconv, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "dprint";
@@ -11,7 +11,12 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-DauLzn+QkqTCPubrtasAZmD3DrIXkHk7zd8g589TCCk=";
 
-  buildInputs = lib.optionals stdenv.isDarwin [ Security Foundation libiconv ];
+  buildInputs = lib.optionals stdenv.isDarwin [
+    Security
+    pkgs.darwin.apple_sdk_11_0.frameworks.CoreFoundation
+    pkgs.darwin.apple_sdk_11_0.frameworks.SystemConfiguration
+    libiconv
+  ];
 
   # Tests fail because they expect a test WASM plugin. Tests already run for
   # every commit upstream on GitHub Actions

--- a/pkgs/development/tools/dprint/default.nix
+++ b/pkgs/development/tools/dprint/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchCrate, rustPlatform, libiconv, Security }:
+{ lib, stdenv, fetchCrate, rustPlatform, libiconv, Security, Foundation }:
 
 rustPlatform.buildRustPackage rec {
   pname = "dprint";
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-DauLzn+QkqTCPubrtasAZmD3DrIXkHk7zd8g589TCCk=";
 
-  buildInputs = lib.optionals stdenv.isDarwin [ Security libiconv ];
+  buildInputs = lib.optionals stdenv.isDarwin [ Security Foundation libiconv ];
 
   # Tests fail because they expect a test WASM plugin. Tests already run for
   # every commit upstream on GitHub Actions

--- a/pkgs/development/tools/dprint/default.nix
+++ b/pkgs/development/tools/dprint/default.nix
@@ -14,8 +14,6 @@ rustPlatform.buildRustPackage rec {
   buildInputs = lib.optionals stdenv.isDarwin [
     Security
     darwin.apple_sdk_11_0.frameworks.CoreFoundation
-    darwin.apple_sdk_11_0.frameworks.SystemConfiguration
-    libiconv
   ];
 
   # Tests fail because they expect a test WASM plugin. Tests already run for

--- a/pkgs/development/tools/dprint/default.nix
+++ b/pkgs/development/tools/dprint/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchCrate, rustPlatform, libiconv, Security, darwin }:
+{ lib, stdenv, fetchCrate, rustPlatform, Security, CoreFoundation }:
 
 rustPlatform.buildRustPackage rec {
   pname = "dprint";
@@ -11,10 +11,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-DauLzn+QkqTCPubrtasAZmD3DrIXkHk7zd8g589TCCk=";
 
-  buildInputs = lib.optionals stdenv.isDarwin [
-    Security
-    darwin.apple_sdk_11_0.frameworks.CoreFoundation
-  ];
+  buildInputs = lib.optionals stdenv.isDarwin [ Security CoreFoundation ];
 
   # Tests fail because they expect a test WASM plugin. Tests already run for
   # every commit upstream on GitHub Actions

--- a/pkgs/development/tools/dprint/default.nix
+++ b/pkgs/development/tools/dprint/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchCrate, rustPlatform, Security, CoreFoundation }:
+{ lib, stdenv, fetchCrate, rustPlatform, CoreFoundation, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "dprint";
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-DauLzn+QkqTCPubrtasAZmD3DrIXkHk7zd8g589TCCk=";
 
-  buildInputs = lib.optionals stdenv.isDarwin [ Security CoreFoundation ];
+  buildInputs = lib.optionals stdenv.isDarwin [ CoreFoundation Security ];
 
   # Tests fail because they expect a test WASM plugin. Tests already run for
   # every commit upstream on GitHub Actions

--- a/pkgs/development/tools/dprint/default.nix
+++ b/pkgs/development/tools/dprint/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchCrate, rustPlatform, Security }:
+{ lib, stdenv, fetchCrate, rustPlatform, libiconv, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "dprint";
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-DauLzn+QkqTCPubrtasAZmD3DrIXkHk7zd8g589TCCk=";
 
-  buildInputs = lib.optionals stdenv.isDarwin [ Security ];
+  buildInputs = lib.optionals stdenv.isDarwin [ Security libiconv ];
 
   # Tests fail because they expect a test WASM plugin. Tests already run for
   # every commit upstream on GitHub Actions

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18963,7 +18963,7 @@ with pkgs;
   dbt = with python3Packages; toPythonApplication dbt-core;
 
   dprint = callPackage ../development/tools/dprint {
-    inherit (darwin.apple_sdk.frameworks) Security;
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
 
   devbox = callPackage ../development/tools/devbox { buildGoModule = buildGo121Module; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18963,7 +18963,7 @@ with pkgs;
   dbt = with python3Packages; toPythonApplication dbt-core;
 
   dprint = callPackage ../development/tools/dprint {
-    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+    inherit (darwin.apple_sdk_11_0.frameworks) CoreFoundation Security;
   };
 
   devbox = callPackage ../development/tools/devbox { buildGoModule = buildGo121Module; };


### PR DESCRIPTION
https://github.com/kachick/dotfiles/pull/337#discussion_r1359286945
https://github.com/NixOS/nixpkgs/pull/260107
https://github.com/dprint/dprint/compare/0.40.2...0.41.0

```
building '/nix/store/i2f0hh2px2r6cb0kcqa0sca8acd5xjaj-dprint-0.41.0.drv'...
error: builder for '/nix/store/i2f0hh2px2r6cb0kcqa0sca8acd5xjaj-dprint-0.41.0.drv' failed with exit code 101;
       last 10 log lines:
       >                 sysinfo::apple::disk::get_disks::hf0f5e9ca54811ca0 in libsysinfo-2ada6af970649dda.rlib(sysinfo-2ada6af970649dda.sysinfo.7c30ee2e47e3fa9d-cgu.12.rcgu.o)
       >             "_kCFURLVolumeAvailableCapacityKey", referenced from:
       >                 _$LT$sysinfo..apple..disk..Disk$u20$as$u20$sysinfo..traits..DiskExt$GT$::refresh::h54fb3881d5127506 in libsysinfo-2ada6af970649dda.rlib(sysinfo-2ada6af970649dda.sysinfo.7c30ee2e47e3fa9d-cgu.12.rcgu.o)
       >                 sysinfo::apple::disk::get_disks::hf0f5e9ca54811ca0 in libsysinfo-2ada6af970649dda.rlib(sysinfo-2ada6af970649dda.sysinfo.7c30ee2e47e3fa9d-cgu.12.rcgu.o)
       >           ld: symbol(s) not found for architecture x86_64
       >           clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
       >           
       >
       > warning: `dprint` (bin "dprint") generated 2 warnings
       > error: could not compile `dprint` (bin "dprint") due to previous error; 2 warnings emitted
       For full logs, run 'nix log /nix/store/i2f0hh2px2r6cb0kcqa0sca8acd5xjaj-dprint-0.41.0.drv'.
error: 1 dependencies of derivation '/nix/store/s4pzwdw10iphsaygaaf4kypsg78kl4sa-nix-shell-env.drv' failed to build
```