### PR TITLE
[Experimental] gh-poi: init at 0.9.7

### DIFF
--- a/pkgs/by-name/gh/gh-poi/package.nix
+++ b/pkgs/by-name/gh/gh-poi/package.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildGo119Module
+, fetchFromGitHub
+}:
+
+let
+  pname = "gh-poi";
+  version = "0.9.7";
+
+  src = fetchFromGitHub {
+    owner = "seachicken";
+    repo = "gh-poi";
+    rev = "v${version}";
+    hash = "sha256-wSyKTi/OAq/+tS1STmGa3QMrzyyBh/Q01xY0qPtHJdc=";
+  };
+in
+buildGo119Module {
+  inherit pname version src;
+
+  vendorHash = "sha256-D/YZLwwGJWCekq9mpfCECzJyJ/xSlg7fC6leJh+e8i0=";
+
+  # tests require network access
+  doCheck = false;
+
+  ldflags = [ "-s" "-w" ];
+
+  meta = with lib; {
+    description = "Safely clean up your local branches";
+    homepage = "https://github.com/seachicken/gh-poi";
+    changelog = "https://github.com/seachicken/gh-poi/releases/tag/${src.rev}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kachick ];
+    mainProgram = "gh-poi";
+  };
+}


### PR DESCRIPTION
Resolves https://github.com/kachick/dotfiles/issues/276 if this will be send to upstream and merged. But ...

failed after build around tests as https://github.com/seachicken/gh-poi/tree/da77b46abaf7cb202f6c0c8dd780b654a14ac708/conn

They are avoiding in CI https://github.com/seachicken/gh-poi/blob/da77b46abaf7cb202f6c0c8dd780b654a14ac708/.github/workflows/ci.yml#L43

Looks like related to https://discourse.nixos.org/t/buildgomodule-fails-during-tests/14971

I don't know how to avoid 🤷‍♂️ 

