### PR TITLE
winboat: fix broken build by pinning dependencies

### DIFF
--- a/pkgs/by-name/wi/winboat/guest-server.nix
+++ b/pkgs/by-name/wi/winboat/guest-server.nix
@@ -1,8 +1,11 @@
 {
   lib,
-  buildGoModule,
+  buildGo125Module,
   winboat,
 }:
+let
+  buildGoModule = buildGo125Module;
+in
 buildGoModule {
   inherit (winboat) version src;
   modRoot = "guest_server";

--- a/pkgs/by-name/wi/winboat/package.nix
+++ b/pkgs/by-name/wi/winboat/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  electron,
+  electron_40,
   zip,
   nodejs_24,
   makeWrapper,
@@ -17,6 +17,9 @@
   nix-update-script,
 }:
 
+let
+  electron = electron_40;
+in
 buildNpmPackage (finalAttrs: {
   pname = "winboat";
   version = "0.9.0";


### PR DESCRIPTION
`https://github.com/NixOS/nixpkgs/issues/503112`
https://github.com/kachick/dotfiles/pull/1518


I'm not sure for nixpkgs PR because upstream does not nodejs_25 and nixpkgs still have nodejs_24. It is still LTS version.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
